### PR TITLE
Add 3.1.0 Upgrade 3.1.50

### DIFF
--- a/GenshinImpact_Beta/3.1.5x.md
+++ b/GenshinImpact_Beta/3.1.5x.md
@@ -12,6 +12,8 @@
 
 ---
 
+**Update | 3.1.0 - 3.1.50 | [Third party Baidu online disk](bing.com/)**
+
 **[Update | 3.1.51 - 3.1.52](https://osbetadownload.yuanshen.com/client_app/beta_update/private/hk4e_global/36/game_3.1.51_3.1.52_hdiff_tcRkLIu75JfKmQMj.zip)**
 
 **[Update | 3.1.51 - 3.1.53](https://osbetadownload.yuanshen.com/client_app/beta_update/private/hk4e_global/36/game_3.1.51_3.1.53_hdiff_EclUqByjXFMALKs3.zip)**

--- a/GenshinImpact_Beta/3.1.5x.md
+++ b/GenshinImpact_Beta/3.1.5x.md
@@ -12,7 +12,7 @@
 
 ---
 
-**Update | 3.1.0 - 3.1.50 | [Third party Baidu online disk](bing.com/)**
+**Update | 3.1.0 - 3.1.50 | [Third party onedrive](https://rainkavik-my.sharepoint.com/:f:/p/kong/ElO20Bd2sghGqYhf0tA7p_oBPzjLMhT41ABPV17jr2r5JQ?e=wRw9m1)**
 
 **[Update | 3.1.51 - 3.1.52](https://osbetadownload.yuanshen.com/client_app/beta_update/private/hk4e_global/36/game_3.1.51_3.1.52_hdiff_tcRkLIu75JfKmQMj.zip)**
 


### PR DESCRIPTION
I'm very sorry. I haven't seen your invitation because I don't often watch github. I hope I can invite you again after PR passes. Thank you
I didn't find the official link. I only found the third party link
Genshin3.1.0_ 3.1.50_ Hdiff.zip has a problem naming the internal folder due to the compression problem Genshin3.1.0_ 3.1.50_ Hdiff.zip should be an official ua, not gc